### PR TITLE
[Setting] Jetpack Compose

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,14 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    buildFeatures {
+        // Enables Jetpack Compose for this module
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.0.0-beta07'
+    }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -24,22 +32,44 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 }
 
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.2.0'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.3'
-    testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+
+    /* Jetpack Compose */
+    implementation 'androidx.compose.ui:ui:1.0.0-rc01'
+    // Tooling support (Previews, etc.)
+    implementation 'androidx.compose.ui:ui-tooling:1.0.0-rc01'
+    // Foundation (Border, Background, Box, Image, Scroll, shapes, animations, etc.)
+    implementation 'androidx.compose.foundation:foundation:1.0.0-rc01'
+    // Material Design
+    implementation 'androidx.compose.material:material:1.0.0-rc01'
+    // Material design icons
+    implementation 'androidx.compose.material:material-icons-core:1.0.0-rc01'
+    implementation 'androidx.compose.material:material-icons-extended:1.0.0-rc01'
+    // Integration with activities
+    implementation 'androidx.activity:activity-compose:1.3.0-rc01'
+    // Integration with ViewModels
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha07'
+    // Integration with observables
+    implementation 'androidx.compose.runtime:runtime-livedata:1.0.0-rc01'
+    implementation 'androidx.compose.runtime:runtime-rxjava2:1.0.0-rc01'
+
+    // UI Tests
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4:1.0.0-rc01'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.3"
+        classpath 'com.android.tools.build:gradle:7.0.0-beta05'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,9 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+kotlin.incremental=true
+kapt.incremental.apt=true
+
+org.gradle.caching=true
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip


### PR DESCRIPTION
- Jetpack Compose 설정 추가
    - Jetpack Compose를 사용하기 위해서는 IDE 버전이 4.3 이상이여야 함
        - 현재 beta 버전으로 release 되어 있음 (Arctic Fox)
    - IDE 4.3 버전의 경우 JDK 11 버전을 사용해서 complie 옵션 변경
    - Gradle 버전 및 Gradle Plugin 버전 업그레이드
        - Gradle: 6.5 -> 7.0.2
        - Gradle Plugin: 4.1.3 -> 7.0.0-beta05